### PR TITLE
Partitioned projections can now supply partition Id selectors

### DIFF
--- a/src/EventServe.Extensions.Microsoft.DependencyInjection/EventServeExtensions.cs
+++ b/src/EventServe.Extensions.Microsoft.DependencyInjection/EventServeExtensions.cs
@@ -29,6 +29,7 @@ namespace EventServe.Extensions.Microsoft.DependencyInjection
             services.ConnectImplementationsToTypesClosing(typeof(ISubscriptionEventHandler<,>), assemblies, false);
             services.ConnectImplementationsToTypesClosing(typeof(IProjectionEventHandler<,>), assemblies, false);
             services.ConnectImplementationsToTypesClosing(typeof(IPartitionedProjectionEventHandler<,>), assemblies, false);
+            services.ConnectImplementationsToTypesClosing(typeof(IPartitionedProjectionPartitionIdSelector<,>), assemblies, false);
             services.ConnectImplementationsToTypesClosing(typeof(IPersistentSubscriptionResetHandler<>), assemblies, false);
             services.AddTransient(typeof(IEventRepository<>), typeof(EventRepository<>));
             services.AddTransient(typeof(IPartitionedProjectionQuery<>), typeof(PartitionedProjectionQuery<>));

--- a/src/EventServe/EventServe.csproj
+++ b/src/EventServe/EventServe.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/EventServe/Projections/Partitioned/IPartitionedProjectionPartitionIdSelector.cs
+++ b/src/EventServe/Projections/Partitioned/IPartitionedProjectionPartitionIdSelector.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventServe.Projections.Partitioned
+{
+    public interface IPartitionedProjectionPartitionIdSelector<TProjection, TEvent>
+       where TProjection : PartitionedProjection, new()
+       where TEvent : Event
+    {
+        Task<Guid> GetPartitionId(TEvent @event);
+    }
+}


### PR DESCRIPTION
Partitioned projections can now supply partition Id selectors for each event

- This is useful for nested projections